### PR TITLE
nullの場合の挙動を設定できるように

### DIFF
--- a/src/main/java/io/github/lambig/patterns/WhenValueIsNull.java
+++ b/src/main/java/io/github/lambig/patterns/WhenValueIsNull.java
@@ -1,0 +1,58 @@
+package io.github.lambig.patterns;
+
+import java.util.function.Supplier;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Patternsの処理の実行結果がnullだった場合の挙動
+ */
+
+public interface WhenValueIsNull<V> extends Supplier<V> {
+    static <T> WhenValueIsNull<T> returnDefaultValue(final T value) {
+        return new ReturnDefaultValue<>(value);
+    }
+
+    static <T> WhenValueIsNull<T> returnNull() {
+        return new ReturnNull<>();
+    }
+
+    static <T> WhenValueIsNull<T> throwRuntimeException(final String message) {
+        return new ThrowRuntimeException<>(new RuntimeException(message));
+    }
+
+    static <T> WhenValueIsNull<T> throwRuntimeException(final Throwable t) {
+        return new ThrowRuntimeException<>(t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(t));
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    class ReturnDefaultValue<V> implements WhenValueIsNull<V> {
+        private final V value;
+
+        @Override
+        public V get() {
+            return value;
+        }
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    class ReturnNull<V> implements WhenValueIsNull<V> {
+        @Override
+        public V get() {
+            return null;
+        }
+    }
+
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    class ThrowRuntimeException<V> implements WhenValueIsNull<V> {
+        private final RuntimeException runtimeException;
+
+        @Override
+        public V get() {
+            throw runtimeException;
+        }
+    }
+
+}

--- a/src/test/java/io/github/lambig/patterns/PatternsTest.java
+++ b/src/test/java/io/github/lambig/patterns/PatternsTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +111,29 @@ class PatternsTest {
             } catch (RuntimeException e) {
                 assertThat(e).hasMessage("この値はパターンにありません: 0");
             }
+        }
+
+        @Test
+        void nullの場合にデフォルト値を返す() {
+            final String defaultValue = "未設定なのでdefaultを設定";
+            final Object actual = Patterns.<String, String>of(WhenValueIsNull.returnDefaultValue(defaultValue), P.orElse(v -> null)).get("init");
+            Assertions.assertEquals(defaultValue, actual);
+        }
+
+        @Test
+        void nullもそのままnullを返す() {
+            final Object actual = Patterns.<String, String>of(WhenValueIsNull.returnNull(), P.orElse(v -> null)).get("init");
+            Assertions.assertNull(actual);
+        }
+
+        @Test
+        void nullの場合に例外を返す() {
+            Assertions.assertThrows(RuntimeException.class, () -> Patterns.<String, String>of(WhenValueIsNull.throwRuntimeException(new Exception("error!")), P.orElse(v -> null)).get("init"));
+        }
+
+        @Test
+        void 未設定_例外を返す() {
+            Assertions.assertThrows(RuntimeException.class, () -> Patterns.<String, String>of(P.orElse(v -> null)).get("init"));
         }
 
         //SetUp


### PR DESCRIPTION
`Patterns` で実行の結果がnullの場合の挙動を、設定できるようにしました。
下記の3つのいずれかが設定できます。

- `WhenValueIsNull.returnDefaultValue(Hoge)`: 指定のデフォルト値を返す
  ```
  final Object actual = Patterns.<String, String>of(WhenValueIsNull.returnDefaultValue("Hoge"), P.orElse(v -> null)).get("init");
  System.out.println(actual); // -> Hoge
  ```

- `WhenValueIsNull.returnNull()`: nullをそのまま返す
  ```
  final Object actual = Patterns.<String, String>of(WhenValueIsNull.returnNull(), P.orElse(v -> null)).get("init");
  System.out.println(actual); // -> null
  ```

- `WhenValueIsNull.throwRuntimeException(Hoge)`: 例外を返す
  ```
  Patterns.<String, String>of(WhenValueIsNull.throwRuntimeException(new Exception("error!")), P.orElse(v -> null)).get("init"); // -> throw Exception
  ```

- デフォルト（未設定）時は、nullの場合は例外発生（null考慮してないのにnullになるのはゆるせない）
  ```
  Patterns.<String, String>of(P.orElse(v -> null)).get("init"); // -> throw Exception
  ```
